### PR TITLE
Add option to run terraform output

### DIFF
--- a/bin/dome
+++ b/bin/dome
@@ -17,6 +17,7 @@ EOS
   opt :apply, 'Applies a Terraform plan'
   opt :plan_destroy, 'Creates a destructive Terraform plan'
   opt :state, 'Synchronises the Terraform state'
+  opt :output, 'Print all Terraform output variables'
 end
 
 Trollop.educate unless opts.has_value?(true)
@@ -32,4 +33,6 @@ elsif opts[:plan_destroy]
   @dome.plan_destroy
 elsif opts[:state]
   @dome.state.s3_state
+elsif opts[:output]
+  @dome.output
 end

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -77,5 +77,6 @@ module Dome
       command         = 'terraform output'
       failure_message = 'something went wrong when printing TF output variables'
       execute_command(command, failure_message)
+    end
   end
 end

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -72,5 +72,10 @@ module Dome
       failure_message = 'something went wrong when pulling remote TF modules'
       execute_command(command, failure_message)
     end
+
+    def output
+      command         = 'terraform output'
+      failure_message = 'something went wrong when printing TF output variables'
+      execute_command(command, failure_message)
   end
 end


### PR DESCRIPTION
Adds in option to run `terraform output` to get all Terraform output variables from the plan