### PR TITLE
[WIP] Add SimpleDB locking

### DIFF
--- a/bin/dome
+++ b/bin/dome
@@ -33,6 +33,8 @@ begin
     @dome.state.s3_state
   elsif opts[:output]
     @dome.output
+  elsif opts[:unlock]
+    @dome.purge_locks
   end
 rescue Interrupt
   puts "\ndome execution interrupted!".colorize(:red)

--- a/bin/dome
+++ b/bin/dome
@@ -17,6 +17,7 @@ EOS
   opt :apply, 'Applies a Terraform plan'
   opt :state, 'Synchronises the Terraform state'
   opt :output, 'Print all Terraform output variables'
+  opt :unlock, 'Unlock the SimpleDB lock for Terraform state'
 end
 
 Trollop.educate unless opts.value?(true)

--- a/dome.gemspec
+++ b/dome.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.37'
 
   spec.add_dependency 'trollop', '~> 2.1'
-  spec.add_dependency 'aws-sdk', '~> 2.1'
+  spec.add_dependency 'aws-sdk', '~> 2'
   spec.add_dependency 'colorize', '~> 0.7'
   spec.add_dependency 'hiera', '~> 1.3'
   spec.add_dependency 'hiera-eyaml', '~> 2.1'

--- a/dome.gemspec
+++ b/dome.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'colorize', '~> 0.7'
   spec.add_dependency 'hiera', '~> 1.3'
   spec.add_dependency 'hiera-eyaml', '~> 2.1'
+  spec.add_dependency 'sdb_lock', '~> 0.1.1'
 end

--- a/lib/dome.rb
+++ b/lib/dome.rb
@@ -4,6 +4,7 @@ require 'colorize'
 require 'fileutils'
 require 'yaml'
 require 'hiera'
+require 'sdb_lock'
 
 require 'dome/settings'
 require 'dome/version'

--- a/lib/dome/helpers/shell.rb
+++ b/lib/dome/helpers/shell.rb
@@ -2,8 +2,9 @@ module Dome
   module Shell
     def execute_command(command, failure_message)
       puts "About to execute command: #{command.colorize(:yellow)}"
-      success = system command
-      puts failure_message unless success
+      result = system command
+      puts failure_message unless result
+      result
     end
   end
 end

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -18,6 +18,12 @@ module Dome
       @s3_client ||= Aws::S3::Client.new
     end
 
+    def sdb_lock
+      @sdb_lock ||= SdbLock.new(state_bucket_name,
+                                create_domain: true,
+                                simple_db_endpoint: 'sdb.eu-west-1.amazonaws.com')
+    end
+
     def list_buckets
       s3_client.list_buckets
     end

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -14,12 +14,16 @@ module Dome
       "#{@environment.environment}-terraform.tfstate"
     end
 
+    def sdb_lock_name
+      state_bucket_name.gsub!(/(-)/, '_')
+    end
+
     def s3_client
       @s3_client ||= Aws::S3::Client.new
     end
 
     def sdb_lock
-      @sdb_lock ||= SdbLock.new(state_bucket_name.gsub!(/(-)/,'_'))
+      @sdb_lock ||= SdbLock.new(sdb_lock_name)
     end
 
     def list_buckets

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -19,7 +19,7 @@ module Dome
     end
 
     def sdb_lock
-      @sdb_lock ||= SdbLock.new(state_bucket_name, simple_db_endpoint: 'sdb.eu-west-1.amazonaws.com')
+      @sdb_lock ||= SdbLock.new(state_bucket_name)
     end
 
     def list_buckets

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -19,9 +19,7 @@ module Dome
     end
 
     def sdb_lock
-      @sdb_lock ||= SdbLock.new(state_bucket_name,
-                                create_domain: true,
-                                simple_db_endpoint: 'sdb.eu-west-1.amazonaws.com')
+      @sdb_lock ||= SdbLock.new(state_bucket_name, simple_db_endpoint: 'sdb.eu-west-1.amazonaws.com')
     end
 
     def list_buckets

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -15,11 +15,11 @@ module Dome
     end
 
     def sdb_lock_name
-      state_file_name.gsub!(/(-)/, '_').gsub!(/(\.)/, '_')
+      state_file_name.gsub!(/(-|\.)/, '_')
     end
 
     def sdb_domain_name
-      state_bucket_name.gsub!(/(-)/, '_').gsub!(/(\.)/, '_')
+      state_bucket_name.gsub!(/(-|\.)/, '_')
     end
 
     def s3_client

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -19,7 +19,7 @@ module Dome
     end
 
     def sdb_lock
-      @sdb_lock ||= SdbLock.new(state_bucket_name)
+      @sdb_lock ||= SdbLock.new(state_bucket_name.gsub!(/(-)/,'_'))
     end
 
     def list_buckets

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -15,11 +15,11 @@ module Dome
     end
 
     def sdb_lock_name
-      state_file_name.gsub!(/(-)/, '_').gsub!(/(.)/, '_')
+      state_file_name.gsub!(/(-)/, '_').gsub!(/(\.)/, '_')
     end
 
     def sdb_domain_name
-      state_bucket_name.gsub!(/(-)/, '_').gsub!(/(.)/, '_')
+      state_bucket_name.gsub!(/(-)/, '_').gsub!(/(\.)/, '_')
     end
 
     def s3_client

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -27,7 +27,7 @@ module Dome
     end
 
     def sdb_lock
-      @sdb_lock ||= SdbLock.new(sdb_domain_name, simple_db_endpoint: 'sdb.eu-west-1.amazonaws.com')
+      @sdb_lock ||= SdbLock.new(sdb_domain_name)
     end
 
     def list_buckets

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -15,7 +15,11 @@ module Dome
     end
 
     def sdb_lock_name
-      state_bucket_name.gsub!(/(-)/, '_')
+      state_file_name.gsub!(/(-)/, '_').gsub!(/(.)/, '_')
+    end
+
+    def sdb_domain_name
+      state_bucket_name.gsub!(/(-)/, '_').gsub!(/(.)/, '_')
     end
 
     def s3_client
@@ -23,7 +27,7 @@ module Dome
     end
 
     def sdb_lock
-      @sdb_lock ||= SdbLock.new(sdb_lock_name)
+      @sdb_lock ||= SdbLock.new(sdb_domain_name, simple_db_endpoint: 'sdb.eu-west-1.amazonaws.com')
     end
 
     def list_buckets

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -95,7 +95,7 @@ module Dome
       raise 'Dome has determined that state modification is currently locked'
     end
 
-    def purge_locks(age = nil)
+    def purge_locks(age = 10)
       @state.sdb_lock.unlock_old(age)
     end
 

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -92,7 +92,8 @@ module Dome
     end
 
     def raise_lock
-      puts "SimpleDB locking mechanism indicates that #{@state.sdb_lock_name} lock is currently in place...".colorize(:red)
+      puts "SimpleDB locking mechanism indicates that #{@state.sdb_lock_name}" +
+           'lock is currently in place...'.colorize(:red)
       raise 'Dome has determined that state modification is currently locked'
     end
 

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -42,16 +42,16 @@ module Dome
       delete_plan_file
       install_terraform_modules
       @state.s3_state
-      raise_lock if @state.sdb_lock.try_lock
-      @state.sdb_lock.try_lock(@state.state_file_name) do
+      raise_lock if @state.sdb_lock.try_lock(@state.sdb_lock_name)
+      @state.sdb_lock.try_lock(@state.sdb_lock_name) do
         create_plan
       end
     end
 
     def apply
       @secrets.secret_env_vars
-      raise_lock if @state.sdb_lock.try_lock
-      @state.sdb_lock.try_lock(@state.state_file_name) do
+      raise_lock if @state.sdb_lock.try_lock(@state.sdb_lock_name)
+      @state.sdb_lock.try_lock(@state.sdb_lock_name) do
         apply_plan
       end
     end

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -42,7 +42,6 @@ module Dome
       delete_plan_file
       install_terraform_modules
       @state.s3_state
-      puts @state.sdb_lock.locked_resources
       raise_lock if @state.sdb_lock.locked_resources.include? @state.sdb_lock_name
       @state.sdb_lock.lock(@state.sdb_lock_name) do
         create_plan
@@ -93,6 +92,7 @@ module Dome
     end
 
     def raise_lock
+      puts "SimpleDB locking mechanism indicates that #{@state.sdb_lock_name} lock is currently in place...".colorize(:red)
       raise 'Dome has determined that state modification is currently locked'
     end
 

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -42,14 +42,25 @@ module Dome
       delete_plan_file
       install_terraform_modules
       @state.s3_state
-      create_plan
+      locked = @state.sdb_lock.try_lock(@state.state_file_name) do
+        create_plan
+      end
+      raise_lock if locked
     end
 
     def apply
       @secrets.secret_env_vars
+      locked = @state.sdb_lock.try_lock(@state.state_file_name) do
+        apply_plan
+      end
+      raise_lock if locked
+    end
+
+    def apply_plan
       command         = "terraform apply #{@plan_file}"
       failure_message = 'something went wrong when applying the TF plan'
-      execute_command(command, failure_message)
+      result = execute_command(command, failure_message)
+      return result
     end
 
     def create_plan
@@ -57,7 +68,8 @@ module Dome
       @secrets.extract_certs
       command         = "terraform plan -refresh=true -out=#{@plan_file} -var-file=params/env.tfvars"
       failure_message = 'something went wrong when creating the TF plan'
-      execute_command(command, failure_message)
+      result = execute_command(command, failure_message)
+      return result
     end
 
     def delete_terraform_directory
@@ -76,13 +88,21 @@ module Dome
     def install_terraform_modules
       command         = 'terraform get -update=true'
       failure_message = 'something went wrong when pulling remote TF modules'
-      execute_command(command, failure_message)
+      purge_locks if execute_command(command, failure_message)
+    end
+
+    def raise_lock
+      raise 'Dome has determined that state modification is currently locked'
+    end
+
+    def purge_locks(age=nil)
+      @state.sdb_lock.unlock_old(age)
     end
 
     def output
       command         = 'terraform output'
       failure_message = 'something went wrong when printing TF output variables'
-      execute_command(command, failure_message)
+      result = execute_command(command, failure_message)
     end
   end
 end

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -42,18 +42,18 @@ module Dome
       delete_plan_file
       install_terraform_modules
       @state.s3_state
-      locked = @state.sdb_lock.try_lock(@state.state_file_name) do
+      raise_lock if @state.sdb_lock.try_lock
+      @state.sdb_lock.try_lock(@state.state_file_name) do
         create_plan
       end
-      raise_lock if locked
     end
 
     def apply
       @secrets.secret_env_vars
-      locked = @state.sdb_lock.try_lock(@state.state_file_name) do
+      raise_lock if @state.sdb_lock.try_lock
+      @state.sdb_lock.try_lock(@state.state_file_name) do
         apply_plan
       end
-      raise_lock if locked
     end
 
     def apply_plan

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -42,16 +42,17 @@ module Dome
       delete_plan_file
       install_terraform_modules
       @state.s3_state
-      raise_lock if @state.sdb_lock.try_lock(@state.sdb_lock_name)
-      @state.sdb_lock.try_lock(@state.sdb_lock_name) do
+      puts @state.sdb_lock.locked_resources
+      raise_lock if @state.sdb_lock.locked_resources.any?(/(#{@state.sdb_lock_name})/)
+      @state.sdb_lock.lock(@state.sdb_lock_name) do
         create_plan
       end
     end
 
     def apply
       @secrets.secret_env_vars
-      raise_lock if @state.sdb_lock.try_lock(@state.sdb_lock_name)
-      @state.sdb_lock.try_lock(@state.sdb_lock_name) do
+      raise_lock if @state.sdb_lock.locked_resources.any?(/(#{@state.sdb_lock_name})/)
+      @state.sdb_lock.lock(@state.sdb_lock_name) do
         apply_plan
       end
     end

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -60,7 +60,7 @@ module Dome
       command         = "terraform apply #{@plan_file}"
       failure_message = 'something went wrong when applying the TF plan'
       result = execute_command(command, failure_message)
-      return result
+      result
     end
 
     def create_plan
@@ -69,7 +69,7 @@ module Dome
       command         = "terraform plan -refresh=true -out=#{@plan_file} -var-file=params/env.tfvars"
       failure_message = 'something went wrong when creating the TF plan'
       result = execute_command(command, failure_message)
-      return result
+      result
     end
 
     def delete_terraform_directory
@@ -95,14 +95,14 @@ module Dome
       raise 'Dome has determined that state modification is currently locked'
     end
 
-    def purge_locks(age=nil)
+    def purge_locks(age = nil)
       @state.sdb_lock.unlock_old(age)
     end
 
     def output
       command         = 'terraform output'
       failure_message = 'something went wrong when printing TF output variables'
-      result = execute_command(command, failure_message)
+      execute_command(command, failure_message)
     end
   end
 end

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -43,7 +43,7 @@ module Dome
       install_terraform_modules
       @state.s3_state
       puts @state.sdb_lock.locked_resources
-      raise_lock if @state.sdb_lock.locked_resources.any?(/(#{@state.sdb_lock_name})/)
+      raise_lock if @state.sdb_lock.locked_resources.include? @state.sdb_lock_name
       @state.sdb_lock.lock(@state.sdb_lock_name) do
         create_plan
       end
@@ -51,7 +51,7 @@ module Dome
 
     def apply
       @secrets.secret_env_vars
-      raise_lock if @state.sdb_lock.locked_resources.any?(/(#{@state.sdb_lock_name})/)
+      raise_lock if @state.sdb_lock.locked_resources.include? @state.sdb_lock_name
       @state.sdb_lock.lock(@state.sdb_lock_name) do
         apply_plan
       end
@@ -89,7 +89,7 @@ module Dome
     def install_terraform_modules
       command         = 'terraform get -update=true'
       failure_message = 'something went wrong when pulling remote TF modules'
-      purge_locks if execute_command(command, failure_message)
+      execute_command(command, failure_message)
     end
 
     def raise_lock


### PR DESCRIPTION
- Uses [sdb_lock](https://github.com/pLucky-Inc/sdb_lock) to provide a distributed locking mechanism
- SimpleDB Lock domain and name match the S3 stack bucket and object
- Includes an `--unlock` command line flag to remove stale locks
