### PR TITLE
Terraform 0.10.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,48 @@
+# 6.0.0
+
+BREAKING CHANGE:
+
+  - Terraform 0.10.x support
+
+REQUIRED CHANGES:
+
+  - Add a block for the s3 backend in the `main.tf` (example from root-infra):
+    ```
+    terraform {
+      backend "s3" {
+        bucket         = "root-tfstate-infraprd"
+        key            = "infraprd-terraform.tfstate"
+        region         = "eu-west-1"
+        dynamodb_table = "root-tfstate-infraprd"
+      }
+    }
+    ```
+  - Pin the providers to specific versions: (example from root-infra):
+    ```
+    provider "aws" {
+      region = "${var.region}"
+      version = "1.0.0"
+    }
+
+    provider "template" {
+      version = "1.0.0"
+    }
+
+    provider "terraform" {
+      version = "1.0.0"
+    }
+    ```
+
+# 5.0.0
+
+Update hiera to 3.x, required for projects which implement Puppet 5.x
+
+# 4.0.0
+
+Breaking change:
+
+Ecosystem variable within the ITV yaml now needs to be a hash - the Terraform run will fail hard if the ecosystems are not set to a hash within the config
+
 # 3.1.0
 
 Added hiera-eyaml support.

--- a/bin/dome
+++ b/bin/dome
@@ -5,13 +5,13 @@ require_relative '../lib/dome'
 
 opts = Trollop.options do
   version Dome::VERSION
-  banner <<-EOS
+  banner <<-BANNER
   Dome wraps the Terraform API and performs useful stuff.
 
   Usage:
         dome [command]
   where [commands] are:
-EOS
+BANNER
 
   opt :plan, 'Creates a Terraform plan'
   opt :apply, 'Applies a Terraform plan'

--- a/dome.gemspec
+++ b/dome.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'dome/version'

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -65,8 +65,12 @@ module Dome
         resp = ddb_client.describe_table({
           table_name: bucket_name,
         })
-        return true if resp.to_h[:table][:table_name] == bucket_name
+        if resp.to_h[:table][:table_name] == bucket_name
+          puts "DynamoDB state locking table exists: #{bucket_name}".colorize(:green)
+          return true
+        end
       rescue Aws::DynamoDB::Errors::ResourceNotFoundException => e
+        puts "DynamoDB state locking table doesn't exist! .. creating it".colorize(:yellow)
         return false
       rescue StandardError => e
         raise "Could not read DynamoDB table! error occurred: #{e}"
@@ -91,7 +95,7 @@ module Dome
           },
         })
       rescue StandardError => e
-        raise "Could not create DynamoDB table! error occurred: #{e}"
+        raise "Could not create DynamoDB table! error occurred: #{e}".colorize(:red)
       end
     end
 

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -70,12 +70,5 @@ module Dome
       end
     end
 
-    def synchronise_s3_state(bucket_name, state_file_name)
-      puts 'Synchronising the remote S3 state...'
-      command         = 'terraform remote config -backend=S3'\
-            " -backend-config='bucket=#{bucket_name}' -backend-config='key=#{state_file_name}'"
-      failure_message = 'Something went wrong when synchronising the S3 state.'
-      execute_command(command, failure_message)
-    end
   end
 end

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -40,8 +40,7 @@ module Dome
     def plan
       delete_terraform_directory
       delete_plan_file
-      install_terraform_modules
-      @state.s3_state
+      terraform_init
       create_plan
     end
 
@@ -74,9 +73,9 @@ module Dome
       FileUtils.rm_f @plan_file
     end
 
-    def install_terraform_modules
-      command         = 'terraform get -update=true'
-      failure_message = 'something went wrong when pulling remote TF modules'
+    def terraform_init
+      command         = 'terraform init'
+      failure_message = 'something went wrong when initialising TF'
       execute_command(command, failure_message)
     end
 

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,3 +1,3 @@
 module Dome
-  VERSION = '5.0.0'.freeze
+  VERSION = '6.0.0'.freeze
 end


### PR DESCRIPTION
BREAKING CHANGE:
  - The `remote` subcommand is no longer available, and is replaced by `init`
