### PR TITLE
[WIP] Improve shell output

### DIFF
--- a/lib/dome.rb
+++ b/lib/dome.rb
@@ -7,6 +7,7 @@ require 'fileutils'
 require 'yaml'
 require 'hiera'
 require 'aws_assume_role'
+require 'open3'
 
 require 'dome/settings'
 require 'dome/version'

--- a/lib/dome/helpers/shell.rb
+++ b/lib/dome/helpers/shell.rb
@@ -4,11 +4,11 @@ module Dome
   module Shell
     def execute_command(command, failure_message)
       puts "About to execute command: #{command.colorize(:yellow)}"
-      Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
-        while line = stdout.gets
+      Open3.popen3(command) do |_stdin, stdout, stderr, wait_thr|
+        while line == stdout.gets
           puts line
         end
-        while line = stderr.gets
+        while line == stderr.gets
           puts line
         end
         exit_status = wait_thr.value

--- a/lib/dome/helpers/shell.rb
+++ b/lib/dome/helpers/shell.rb
@@ -4,8 +4,16 @@ module Dome
   module Shell
     def execute_command(command, failure_message)
       puts "About to execute command: #{command.colorize(:yellow)}"
-      success = system command
-      Kernel.abort(failure_message) unless success
+      Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
+        while line = stdout.gets
+          puts line
+        end
+        while line = stderr.gets
+          puts line
+        end
+        exit_status = wait_thr.value
+        Kernel.abort(failure_message) unless exit_status.success?
+      end
     end
   end
 end

--- a/lib/dome/helpers/shell.rb
+++ b/lib/dome/helpers/shell.rb
@@ -2,6 +2,19 @@
 
 module Dome
   module Shell
+    def which(cmd)
+      exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+      ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+        exts.each { |ext|
+          exe = File.join(path, "#{cmd}#{ext}")
+          return exe if File.executable?(exe) && !File.directory?(exe)
+        }
+      end
+      return nil
+    end
+    def binary
+      which 'terraform'
+    end
     def execute_command(command, failure_message)
       puts "About to execute command: #{command.colorize(:yellow)}"
       Open3.popen3(command) do |_stdin, stdout, stderr, wait_thr|

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -17,6 +17,7 @@ module Dome
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
     def validate_environment
+      raise "Cannot find Terraform binary! is it installed?" unless binary
       puts 'Initialising domed-city...'
       puts "* Your 'account' and 'environment' are assigned based on your current directory. "\
           "The expected directory structure is 'terraform/<account>/<environment>'".colorize(:yellow)


### PR DESCRIPTION
- Use `popen3` instead of `system` so that we can capture failure messages more reliably