### PR TITLE
Puppet Key Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.3.2
+
+BUGFIX:
+
+- Give a useful error message if you try to run without Puppet private keys available.
+
 # 6.3.1
 
 BUGFIX:

--- a/lib/dome/hiera_lookup.rb
+++ b/lib/dome/hiera_lookup.rb
@@ -38,6 +38,8 @@ module Dome
         eyaml_directory = File.join(puppet_dir, 'keys')
       elsif File.exist?('/etc/puppet/keys/private_key.pkcs7.pem')
         eyaml_directory = '/etc/puppet/keys'
+      else
+        abort("Puppet private key not in found in either '/etc/puppet/keys' or #{puppet_dir}keys.")
       end
       puts "The configured EYAML directory is: #{eyaml_directory.colorize(:green)}" unless @eyaml_directory
       @eyaml_directory ||= eyaml_directory

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '6.3.1'
+  VERSION = '6.3.2'
 end


### PR DESCRIPTION
Abort with a useful message if you don't have the Private key for Puppet in either of the appropriate directories.