### PR TITLE
Expose TF_VAR_aws_account_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.3.0
+
+FEATURES:
+ - Exports TF_ENV_aws_account_id so the role modules can use it to construct ARN for AWS resources. Is used in tf-aws-role-core to construst the s3 bucket policy.
+
 # 6.2.0
 
 FEATURES:
@@ -5,6 +10,7 @@ FEATURES:
 - Set TF_VAR_product,ecosystem,envname
 - Replace envname with env so we can transition to the new env name
 - You can remove product,envname,ecosystem from your params/env.tfvars as they are now discovered from your directory structure
+
 # 6.1.0
 
 FEATURES:

--- a/lib/dome/environment.rb
+++ b/lib/dome/environment.rb
@@ -5,6 +5,15 @@ module Dome
     attr_reader :environment, :account, :ecosystem, :settings
 
     def initialize(directories = Dir.pwd.split('/'))
+
+      open 'params/env.tfvars' do |file|
+        file.each_line do |line|
+          if line =~ /^aws_account_id/ 
+            ENV['TF_VAR_aws_account_id'] = line.split('=').last.strip.delete('"')
+          end
+        end
+      end
+      
       @environment            = directories[-1]
       @account                = directories[-2]
       @ecosystem              = directories[-2].split('-')[-1]

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '6.2.0'
+  VERSION = '6.3.0'
 end


### PR DESCRIPTION
FEATURES:
 - Exports TF_ENV_aws_account_id so the role modules can use it to construct ARN for AWS resources. Is used in tf-aws-role-core to construst the s3 bucket policy.
