### PR TITLE
BugFix Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.3.1
+
+BUGFIX:
+
+- Remove cidr_ecosystem_dev/prd because they are breaking existing runs(in infraprd). Will enable again in the future once everyone is using 1.1.
+
 # 6.3.0
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ gem 'domed-city', :path => '/home/foo/github-repos/domed-city'
 * Rename project references to product
 * Check the usage of certificate section
 * Remove dynamoDB state locking (Terraform does that now)
-
+* When everyone moves to 1.1 uncomment and use the TF_VARs cidr_ecosystem_dev/prd

--- a/lib/dome/environment.rb
+++ b/lib/dome/environment.rb
@@ -36,8 +36,14 @@ module Dome
       end
 
       ENV['TF_VAR_cidr_ecosystem'] = cidr_ecosystem.join(',').to_s
-      ENV['TF_VAR_cidr_ecosystem_dev'] = cidr_ecosystem_dev.join(',').to_s
-      ENV['TF_VAR_cidr_ecosystem_prd'] = cidr_ecosystem_prd.join(',').to_s
+
+      #
+      # TODO: Will uncomment when all the products migrate to 1.1
+      #
+
+      # ENV['TF_VAR_cidr_ecosystem_dev'] = cidr_ecosystem_dev.join(',').to_s
+      # ENV['TF_VAR_cidr_ecosystem_prd'] = cidr_ecosystem_prd.join(',').to_s
+
       ENV['TF_VAR_dev_ecosystem_environments'] = dev_ecosystem_environments.join(',').to_s
       ENV['TF_VAR_prd_ecosystem_environments'] = prd_ecosystem_environments.join(',').to_s
 
@@ -65,8 +71,14 @@ module Dome
       puts '--- The following TF_VAR are helpers that modules can use ---'
       puts "[*] Setting dev_ecosystem_environments to #{ENV['TF_VAR_dev_ecosystem_environments'].colorize(:green)}"
       puts "[*] Setting prd_ecosystem_environments to #{ENV['TF_VAR_prd_ecosystem_environments'].colorize(:green)}"
-      puts "[*] Setting cidr_ecosystem_dev to #{ENV['TF_VAR_cidr_ecosystem_dev'].colorize(:green)}"
-      puts "[*] Setting cidr_ecosystem_prd to #{ENV['TF_VAR_cidr_ecosystem_prd'].colorize(:green)}"
+
+      #
+      # TODO: Will uncomment when all the products migrate to 1.1
+      #
+
+      # puts "[*] Setting cidr_ecosystem_dev to #{ENV['TF_VAR_cidr_ecosystem_dev'].colorize(:green)}"
+      # puts "[*] Setting cidr_ecosystem_prd to #{ENV['TF_VAR_cidr_ecosystem_prd'].colorize(:green)}"
+
       puts
     end
 


### PR DESCRIPTION
 Removed cidr_ecosystem_dev/prd because they are breaking existing runs(in infraprd). Will enable again in the future once everyone is using 1.1. 