### PR TITLE
add feature to use existing aws environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES:
 - allow option to conserve existing environment variables rather than overriding them
   - this is required for cross account role assuming from `ec2`
   - default behaviour is unchanged
+- update deprecated gem
 
 # 6.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
+# 6.5.0
+
+FEATURES:
+- allow option to conserve existing environment variables rather than overriding them
+  - this is required for cross account role assuming from `ec2`
+  - default behaviour is unchanged
+
 # 6.4.0
+
 
 FEATURES:
  - Added refresh, console and state commands (dome -r,dome -c,dome -t).

--- a/bin/dome
+++ b/bin/dome
@@ -4,7 +4,7 @@
 require 'bundler/setup'
 require_relative '../lib/dome'
 
-opts = Trollop.options do
+opts = Optimist.options do
   version Dome::VERSION
   banner <<-BANNER
   Dome wraps the Terraform API and performs useful stuff.
@@ -23,7 +23,7 @@ opts = Trollop.options do
   opt :console, 'Spawn terraform console'
 end
 
-Trollop.educate unless opts.value?(true)
+Optimist.educate unless opts.value?(true)
 
 @dome = Dome::Terraform.new
 @dome.validate_environment

--- a/dome.gemspec
+++ b/dome.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'colorize', '~> 0.7'
   spec.add_dependency 'hiera', '~> 3'
   spec.add_dependency 'hiera-eyaml', '~> 2.1'
-  spec.add_dependency 'trollop', '~> 2.1'
+  spec.add_dependency 'optimist', '~> 3'
 end

--- a/lib/dome.rb
+++ b/lib/dome.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'trollop'
+require 'optimist'
 require 'aws-sdk'
 require 'colorize'
 require 'fileutils'

--- a/lib/dome/environment.rb
+++ b/lib/dome/environment.rb
@@ -244,23 +244,31 @@ module Dome
     end
 
     def unset_aws_keys
-      puts '[*] Unsetting AWS environment variables from the shell to make sure we are using the correct'\
-      'assumed roles credentials'
-      ENV['AWS_ACCESS_KEY'] = nil
-      ENV['AWS_SECRET_KEY'] = nil
-      ENV['AWS_SECRET_ACCESS_KEY'] = nil
-      ENV['AWS_ACCESS_KEY_ID'] = nil
-      ENV['AWS_SESSION_TOKEN'] = nil
+      unless ENV['FREEZE_AWS_ENVVAR']
+        puts '[*] Unsetting AWS environment variables from the shell to make sure we are using the correct'\
+        'assumed roles credentials'
+        ENV['AWS_ACCESS_KEY'] = nil
+        ENV['AWS_SECRET_KEY'] = nil
+        ENV['AWS_SECRET_ACCESS_KEY'] = nil
+        ENV['AWS_ACCESS_KEY_ID'] = nil
+        ENV['AWS_SESSION_TOKEN'] = nil
+      else
+        puts "$FREEZE_AWS_ENVVAR is set. Leaving AWS environment variables unchanged."
+      end
     end
 
     def export_aws_keys(assumed_role)
-      puts '[*] Exporting temporary credentials to environment variables '\
-      "#{'AWS_ACCESS_KEY_ID'.colorize(:green)}, #{'AWS_SECRET_ACCESS_KEY'.colorize(:green)}"\
-      " and #{'AWS_SESSION_TOKEN'.colorize(:green)}."
-      ENV['AWS_ACCESS_KEY_ID'] = assumed_role.credentials.access_key_id
-      ENV['AWS_SECRET_ACCESS_KEY'] = assumed_role.credentials.secret_access_key
-      ENV['AWS_SESSION_TOKEN'] = assumed_role.credentials.session_token
-      puts
+      unless ENV['FREEZE_AWS_ENVVAR']
+        puts '[*] Exporting temporary credentials to environment variables '\
+        "#{'AWS_ACCESS_KEY_ID'.colorize(:green)}, #{'AWS_SECRET_ACCESS_KEY'.colorize(:green)}"\
+        " and #{'AWS_SESSION_TOKEN'.colorize(:green)}."
+        ENV['AWS_ACCESS_KEY_ID'] = assumed_role.credentials.access_key_id
+        ENV['AWS_SECRET_ACCESS_KEY'] = assumed_role.credentials.secret_access_key
+        ENV['AWS_SESSION_TOKEN'] = assumed_role.credentials.session_token
+        puts
+      else
+        puts "$FREEZE_AWS_ENVVAR is set. Leaving AWS environment variables unchanged."
+      end
     end
 
     def aws_credentials

--- a/lib/dome/environment.rb
+++ b/lib/dome/environment.rb
@@ -244,7 +244,9 @@ module Dome
     end
 
     def unset_aws_keys
-      unless ENV['FREEZE_AWS_ENVVAR']
+      if ENV['FREEZE_AWS_ENVVAR']
+        puts '$FREEZE_AWS_ENVVAR is set. Leaving AWS environment variables unchanged.'
+      else
         puts '[*] Unsetting AWS environment variables from the shell to make sure we are using the correct'\
         'assumed roles credentials'
         ENV['AWS_ACCESS_KEY'] = nil
@@ -252,13 +254,13 @@ module Dome
         ENV['AWS_SECRET_ACCESS_KEY'] = nil
         ENV['AWS_ACCESS_KEY_ID'] = nil
         ENV['AWS_SESSION_TOKEN'] = nil
-      else
-        puts "$FREEZE_AWS_ENVVAR is set. Leaving AWS environment variables unchanged."
       end
     end
 
     def export_aws_keys(assumed_role)
-      unless ENV['FREEZE_AWS_ENVVAR']
+      if ENV['FREEZE_AWS_ENVVAR']
+        puts '$FREEZE_AWS_ENVVAR is set. Leaving AWS environment variables unchanged.'
+      else
         puts '[*] Exporting temporary credentials to environment variables '\
         "#{'AWS_ACCESS_KEY_ID'.colorize(:green)}, #{'AWS_SECRET_ACCESS_KEY'.colorize(:green)}"\
         " and #{'AWS_SESSION_TOKEN'.colorize(:green)}."
@@ -266,8 +268,6 @@ module Dome
         ENV['AWS_SECRET_ACCESS_KEY'] = assumed_role.credentials.secret_access_key
         ENV['AWS_SESSION_TOKEN'] = assumed_role.credentials.session_token
         puts
-      else
-        puts "$FREEZE_AWS_ENVVAR is set. Leaving AWS environment variables unchanged."
       end
     end
 

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '6.4.0'
+  VERSION = '6.5.0'
 end


### PR DESCRIPTION
FEATURES:
- allow option to conserve existing environment variables rather than overriding them
  - this is required for cross account role assuming from `ec2`
  - default behaviour is unchanged
- update deprecated gem