### PR TITLE
prepend itv- to bucket names, add state bootstrap to init cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.7.0
+
+FEATURES:
+- prepend `itv-` to the state bucket names, to help avoid name collision
+- add state bootstrap to init command, with small delay to avoid S3 asynchronicity
+
 # 6.6.0
 
 FEATURES:

--- a/bin/dome
+++ b/bin/dome
@@ -35,7 +35,7 @@ begin
   elsif opts[:apply]
     @dome.apply
   elsif opts[:init]
-    @dome.terraform_init
+    @dome.init
   elsif opts[:refresh]
     @dome.refresh
   elsif opts[:console]

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -12,13 +12,13 @@ module Dome
     def state_bucket_name
       case level
       when 'environment'
-        "terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}"
+        "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}"
       when 'ecosystem'
-        "terraform-state-#{@environment.project}-#{@environment.ecosystem}"
+        "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}"
       when 'product'
-        "terraform-state-#{@environment.project}"
+        "itv-terraform-state-#{@environment.project}"
       when 'roles'
-        "terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}-roles"
+        "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}-roles"
       end
     end
 

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -166,6 +166,12 @@ module Dome
       FileUtils.rm_f @plan_file
     end
 
+    def init
+      @state.s3_state
+      sleep 5
+      terraform_init
+    end
+
     def terraform_init
       command         = 'terraform init'
       failure_message = 'something went wrong when initialising TF'

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '6.6.0'
+  VERSION = '6.7.0'
 end


### PR DESCRIPTION
FEATURES:
- prepend `itv-` to the state bucket names, to help avoid name collision
- add state bootstrap to init command, with small delay to avoid S3 asynchronicity