### PR TITLE
Add --environment command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.15.0
+
+FEATURES:
+- `--environment` command to export variables and spawn a sub-shell
+
 # 6.14.0
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ $ bundle exec dome
   -u, --sudo             Assume itv-root instead of the role specified in profile
   -v, --version          Print version and exit
   -h, --help             Show this message
+  -e, --environment      Spawn sub-shell with the exported variables
 ```
 
 Domed is designed to work with a certain directory structure. Your account,product,ecosystem and environment are assigned based on your current directory. The expected directory structure is terraform/$PRODUCT-$ECOSYSTEM/$ENVIRONMENT

--- a/bin/dome
+++ b/bin/dome
@@ -23,11 +23,20 @@ opts = Optimist.options do
   opt :refresh, 'Refresh the state'
   opt :console, 'Spawn terraform console'
   opt :sudo, 'Assume itv-root instead of the role specified in profile'
+  opt :environment, 'Spawn sub-shell with the exported variables'
 end
 
 Optimist.educate unless opts.value?(true)
 
 @dome = Dome::Terraform.new(sudo: opts[:sudo])
+
+if opts[:environment]
+  puts '--- Spawning shell ---'
+  @dome.spawn_environment_shell
+  puts '--- Exiting shell ---'
+  exit 0
+end
+
 @dome.validate_environment
 
 begin

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -255,5 +255,13 @@ module Dome
       failure_message = 'something went wrong when printing TF output variables'
       execute_command(command, failure_message)
     end
+
+    def spawn_environment_shell
+      @environment.unset_aws_keys
+      @environment.aws_credentials
+
+      shell = ENV['SHELL'] || '/bin/sh'
+      system shell
+    end
   end
 end

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '6.14.0'
+  VERSION = '6.15.0'
 end


### PR DESCRIPTION
```
$ bundle exec dome --environment --sudo
             _
          __| | ___  _ __ ___   ___
        /  _` |/ _ \| '_ ` _ \ / _ \
        | (_| | (_) | | | | | |  __/
         \__,_|\___/|_| |_| |_|\___|

        Wrapping terraform since 2015

[*] Operating at product level

--- Initial TF_VAR variables to drive terraform ---
[*] Setting aws_account_id to 222007316080
[*] Setting product to core
[*] Setting ecosystem to prd
[*] Setting cidr_ecosystem to 10.206.164.0/22,10.206.188.0/22

--- The following TF_VAR are helpers that modules can use ---
[*] Setting dev_ecosystem_environments to infradev,dev
[*] Setting prd_ecosystem_environments to infraprd,prd

--- Product terraform state location ---
[*] S3 bucket name: itv-terraform-state-core
[*] S3 object name: product.tfstate

--- Spawning shell ---
[*] Unsetting AWS environment variables from the shell to make sure we are using the correctassumed roles credentials
[*] Attempting to assume the role defined by your profile for core-prd.
[*] Exporting temporary credentials to environment variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN.

$ aws sts get-caller-identity <--- This is the sub-shell
{
    "UserId": "AROAJH5SISF6PDTIOWDV4:core-prd",
    "Account": "222007316080",
    "Arn": "arn:aws:sts::222007316080:assumed-role/itv-root/core-prd"
}
$ exit
--- Exiting shell ---
$ <--- Back to the main shell
```