### PR TITLE
Pin Terraform providers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Metrics/MethodLength:
   Max: 155
 
 Metrics/ClassLength:
-  Max: 250
+  Max: 300
 
 Metrics/BlockLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.17.0
+
+FEATURES:
+- Install and configure Terraform providers if `.terraform-providers.yaml` file is present in the root of the project
+
 # 6.16.0
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ By default dome will assume the role defined in your AWS profile. If `--sudo` is
 
 Use this mode only when you need to manage resources requiring `itv-root`.
 
+### Pin provider versions
+
+Create a file called `.terraform-providers.yaml` in the root of the project:
+
+```
+aws: 2.6.0
+external: 1.1.0
+local: 1.2.0
+template: 2.1.0
+terraform: 1.0.0
+vault: 1.6.0
+```
+
 ## Development & Releases
 
 In order to make changes, you can point the reference to domed-city in the Gemfile to your local working directory eg

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -279,7 +279,7 @@ module Dome
         plugin_dirs << install_provider(name, version)
       end
 
-      return plugin_dirs.map { |dir| "-plugin-dir #{dir}" }.join(' ')
+      plugin_dirs.map { |dir| "-plugin-dir #{dir}" }.join(' ')
     end
 
     def install_provider(name, version)
@@ -293,19 +293,19 @@ module Dome
         raise 'Invalid platform, only linux and darwin are supported.'
       end
 
-      uri = "https://releases.hashicorp.com/terraform-provider-#{name}/#{version}/terraform-provider-#{name}_#{version}_#{arch}.zip"
+      uri = "https://releases.hashicorp.com/terraform-provider-#{name}/#{version}/terraform-provider-#{name}_#{version}_#{arch}.zip" # rubocop:disable Metrics/LineLength
       dir = File.join(Dir.home, '.terraform.d', 'providers', name, version)
 
       return dir unless Dir[File.join(dir, '*')].empty? # Ruby >= 2.4: Dir.empty? dir
 
       FileUtils.makedirs(dir)
 
-      content = open(uri)
+      content = URI.parse(uri).open
       Zip::File.open_buffer(content) do |zip|
         zip.each { |entry| entry.extract(File.join(dir, entry.name)) }
       end
 
-      return dir
+      dir
     end
   end
 end

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -245,7 +245,9 @@ module Dome
     end
 
     def terraform_init
-      command         = 'terraform init'
+      extra_params = configure_providers
+
+      command         = "terraform init #{extra_params}"
       failure_message = 'something went wrong when initialising TF'
       execute_command(command, failure_message)
     end
@@ -262,6 +264,48 @@ module Dome
 
       shell = ENV['SHELL'] || '/bin/sh'
       system shell
+    end
+
+    private
+
+    def configure_providers
+      providers_config = File.join(@environment.settings.project_root, '.terraform-providers.yaml')
+      return unless File.exist? providers_config
+
+      puts 'Installing providers...'.colorize(:yellow)
+      plugin_dirs = []
+      providers = YAML.load_file(providers_config)
+      providers.each do |name, version|
+        plugin_dirs << install_provider(name, version)
+      end
+
+      return plugin_dirs.map { |dir| "-plugin-dir #{dir}" }.join(' ')
+    end
+
+    def install_provider(name, version)
+      puts "Installing provider #{name}:#{version} ...".colorize(:green)
+
+      if RUBY_PLATFORM =~ /linux/
+        arch = 'linux_amd64'
+      elsif RUBY_PLATFORM =~ /darwin/
+        arch = 'darwin_amd64'
+      else
+        raise 'Invalid platform, only linux and darwin are supported.'
+      end
+
+      uri = "https://releases.hashicorp.com/terraform-provider-#{name}/#{version}/terraform-provider-#{name}_#{version}_#{arch}.zip"
+      dir = File.join(Dir.home, '.terraform.d', 'providers', name, version)
+
+      return dir unless Dir[File.join(dir, '*')].empty? # Ruby >= 2.4: Dir.empty? dir
+
+      FileUtils.makedirs(dir)
+
+      content = open(uri)
+      Zip::File.open_buffer(content) do |zip|
+        zip.each { |entry| entry.extract(File.join(dir, entry.name)) }
+      end
+
+      return dir
     end
   end
 end

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '6.16.0'
+  VERSION = '6.17.0'
 end


### PR DESCRIPTION
This will add the following lines to the dome output if configured:

```
Installing providers...
Installing provider aws:2.6.0 ...
Installing provider external:1.1.0 ...
Installing provider local:1.2.0 ...
Installing provider template:2.1.0 ...
Installing provider terraform:1.0.0 ...
Installing provider vault:1.6.0 ...
[*] Running: terraform init -plugin-dir /home/matefarkas/.terraform.d/providers/aws/2.6.0 -plugin-dir /home/matefarkas/.terraform.d/providers/external/1.1.0 -plugin-dir /home/matefarkas/.terraform.d/providers/local/1.2.0 -plugin-dir /home/matefarkas/.terraform.d/providers/template/2.1.0 -plugin-dir /home/matefarkas/.terraform.d/providers/terraform/1.0.0 -plugin-dir /home/matefarkas/.terraform.d/providers/vault/1.6.0
Downloading modules...

Initializing the backend...

Terraform has been successfully initialized!
```