### PR TITLE
Run dome at roles level

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,9 @@ Documentation:
   Enabled: false
 
 LineLength:
-  Description: 'Limit lines to a more generous 120 characters.'
+  Description: 'Limit lines to a more generous 180 characters.'
   Enabled: true
-  Max: 120
+  Max: 180
 
 Metrics/CyclomaticComplexity:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.0.0
+FEATURES:
+- Add `service` level where a business service can be defined within `<product>-infra/terraform/<product>-<ecosystem>/<environment>/<service>`. This ensures a service-specific AWS S3 bucket and terraform state file.
+
 # 6.18.2
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 6.18.3
+
+FEATURES:
+- Added level support. Where level is ecosystem,environment,product,service  
+
+# 6.18.2
+
+FEATURES:
+- Provide clearer error if required profile is missing from aws config
+
 # 6.18.1
 
 BUGFIX:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,3 @@
-# 6.18.3
-
-FEATURES:
-- Added level support. Where level is ecosystem,environment,product,service  
-
-# 6.18.2
-
-FEATURES:
-- Provide clearer error if required profile is missing from aws config
-
 # 6.18.1
 
 BUGFIX:

--- a/lib/dome/environment.rb
+++ b/lib/dome/environment.rb
@@ -4,7 +4,7 @@
 
 module Dome
   class Environment
-    attr_reader :environment, :account, :settings, :service
+    attr_reader :environment, :account, :settings, :services
 
     include Dome::Level
 

--- a/lib/dome/environment.rb
+++ b/lib/dome/environment.rb
@@ -4,7 +4,7 @@
 
 module Dome
   class Environment
-    attr_reader :environment, :account, :settings
+    attr_reader :environment, :account, :settings, :service
 
     include Dome::Level
 
@@ -34,22 +34,27 @@ module Dome
       when 'environment'
         @environment            = directories[-1]
         @account                = directories[-2]
+        @services               = nil
 
       when 'ecosystem'
         @environment            = nil
         @account                = directories[-1]
+        @services               = nil
 
       when 'product'
         @environment            = nil
         @account                = "#{@product}-prd"
+        @services               = nil
 
-      when 'roles'
+      when 'services'
         @environment            = directories[-2]
         @account                = directories[-3]
+        @services               = directories[-1]
 
       when /^secrets-/
         @environment            = directories[-3]
         @account                = directories[-4]
+        @services               = nil
 
       else
         puts "Invalid level: #{level}".colorize(:red)
@@ -131,7 +136,7 @@ module Dome
       when 'product'
         # FIXME: This is 'prd' if accessed as @ecosystem
         'product'
-      when 'roles'
+      when 'services'
         directories[-3].split('-')[-1]
       when /^secrets-/
         directories[-4].split('-')[-1]

--- a/lib/dome/helpers/level.rb
+++ b/lib/dome/helpers/level.rb
@@ -14,7 +14,7 @@ module Dome
       elsif directories[-3] == 'terraform'
         'environment'
       elsif directories[-4] == 'terraform'
-        'roles'
+        'services'
       elsif directories[-5] == 'terraform' && directories[-2] == 'secrets' && directories[-1] == 'init'
         'secrets-init'
       elsif directories[-5] == 'terraform' && directories[-2] == 'secrets' && directories[-1] == 'config'

--- a/lib/dome/helpers/level.rb
+++ b/lib/dome/helpers/level.rb
@@ -13,7 +13,7 @@ module Dome
         'ecosystem'
       elsif directories[-3] == 'terraform'
         'environment'
-      elsif directories[-4] == 'terraform' && directories[-1] == 'roles'
+      elsif directories[-4] == 'terraform'
         'roles'
       elsif directories[-5] == 'terraform' && directories[-2] == 'secrets' && directories[-1] == 'init'
         'secrets-init'

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -91,7 +91,8 @@ module Dome
     end
 
     def dynamodb_configured?(bucket_name)
-      resp = ddb_client.describe_table(
+      # if the describe works, we know it exists
+      ddb_client.describe_table(
         table_name: bucket_name
       )
     rescue Aws::DynamoDB::Errors::ResourceNotFoundException => e

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -17,8 +17,8 @@ module Dome
         "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}"
       when 'product'
         "itv-terraform-state-#{@environment.project}"
-      when 'roles'
-        "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}-roles"
+      when 'services'
+        "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}-#{@environment.services}" # rubocop:disable Metrics/LineLength
       when /^secrets-/
         "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}-secrets"
       else
@@ -34,7 +34,7 @@ module Dome
         "#{@environment.level}.tfstate"
       when 'product'
         "#{@environment.level}.tfstate"
-      when 'roles'
+      when 'services'
         "#{@environment.level}.tfstate"
       when /^secrets-/
         "#{@environment.level}.tfstate"

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -97,7 +97,7 @@ module Dome
       if resp.to_h[:table][:table_name] == bucket_name
         # TODO: Remove that because terraform handles the locking
         # puts "[*] DynamoDB state locking table exists: #{bucket_name}".colorize(:green)
-        return true
+        true
       end
     rescue Aws::DynamoDB::Errors::ResourceNotFoundException => e
       puts "[*] DynamoDB state locking table doesn't exist! #{e} .. creating it".colorize(:yellow)

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -94,11 +94,6 @@ module Dome
       resp = ddb_client.describe_table(
         table_name: bucket_name
       )
-      if resp.to_h[:table][:table_name] == bucket_name
-        # TODO: Remove that because terraform handles the locking
-        # puts "[*] DynamoDB state locking table exists: #{bucket_name}".colorize(:green)
-        true
-      end
     rescue Aws::DynamoDB::Errors::ResourceNotFoundException => e
       puts "[*] DynamoDB state locking table doesn't exist! #{e} .. creating it".colorize(:yellow)
       false

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -18,7 +18,7 @@ module Dome
       when 'product'
         "itv-terraform-state-#{@environment.project}"
       when 'services'
-        "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}-services"
+        "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}-#{@environment.services}"
       when /^secrets-/
         "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}-secrets"
       else

--- a/lib/dome/state.rb
+++ b/lib/dome/state.rb
@@ -18,7 +18,7 @@ module Dome
       when 'product'
         "itv-terraform-state-#{@environment.project}"
       when 'services'
-        "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}-#{@environment.services}" # rubocop:disable Metrics/LineLength
+        "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}-services"
       when /^secrets-/
         "itv-terraform-state-#{@environment.project}-#{@environment.ecosystem}-#{@environment.environment}-secrets"
       else

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -45,7 +45,7 @@ module Dome
         @environment = Dome::Environment.new
         @secrets     = Dome::Secrets.new(@environment)
         @state       = Dome::State.new(@environment)
-        @plan_file   = "plans/#{@environment.level}-plan.tf"
+        @plan_file   = "plans/#{@environment.services}-plan.tf"
 
         puts '--- Role terraform state location ---'
         puts "[*] S3 bucket name: #{@state.state_bucket_name.colorize(:green)}"

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -41,7 +41,7 @@ module Dome
         puts "[*] S3 bucket name: #{@state.state_bucket_name.colorize(:green)}"
         puts "[*] S3 object name: #{@state.state_file_name.colorize(:green)}"
         puts
-      when 'roles'
+      when 'services'
         @environment = Dome::Environment.new
         @secrets     = Dome::Secrets.new(@environment)
         @state       = Dome::State.new(@environment)
@@ -90,8 +90,8 @@ module Dome
         puts '--- AWS credentials for accessing product state ---'
         @environment.unset_aws_keys
         @environment.aws_credentials
-      when 'roles'
-        puts '--- AWS credentials for accessing roles state ---'
+      when 'services'
+        puts '--- AWS credentials for accessing services state ---'
         environment = @environment.environment
         account     = @environment.account
         @environment.invalid_account_message unless @environment.valid_account? account
@@ -212,7 +212,7 @@ module Dome
         command         = "terraform plan -refresh=true -out=#{@plan_file}"
         failure_message = '[!] something went wrong when creating the product TF plan'
         execute_command(command, failure_message)
-      when 'roles'
+      when 'services'
         @secrets.extract_certs
         FileUtils.mkdir_p 'plans'
         command         = "terraform plan -refresh=true -out=#{@plan_file}"

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -299,7 +299,7 @@ module Dome
         raise 'Invalid platform, only linux and darwin are supported.'
       end
 
-      uri = "https://releases.hashicorp.com/terraform-provider-#{name}/#{version}/terraform-provider-#{name}_#{version}_#{arch}.zip" # rubocop:disable Metrics/LineLength
+      uri = "https://releases.hashicorp.com/terraform-provider-#{name}/#{version}/terraform-provider-#{name}_#{version}_#{arch}.zip"
       dir = File.join(Dir.home, '.terraform.d', 'providers', name, version)
 
       return dir unless Dir[File.join(dir, '*')].empty? # Ruby >= 2.4: Dir.empty? dir

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '6.18.3'
+  VERSION = '6.18.1'
 end

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '6.18.1'
+  VERSION = '6.18.3'
 end

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '6.18.1'
+  VERSION = '7.0.0'
 end


### PR DESCRIPTION
Allow to run dome at other directories one level under environment like "roles"

this allows terraform users to group services, terraform plan/apply on those only and keep a separated state file without contention at the env level.

example
- {product}-dev/
  - {env}/
     - main.tf
          buckets.tf
          other.tf
          lambda/ . <-- can run tf here
          lambda_sqs_and_buckets/  <-- can run tf here

notes:
- no naming convention at all for directories, only defined by the hierarchy level (under environment)

tests:
- used this branch on product cd, created a new dir with a new resource. ran terraform locally successfully at this level & confirmed new state bucket & file for this directory
 