### PR TITLE
allow runlevel services to load params/env.tf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.0.3
+FEATURES:
+- Allow dome to use `params/env.tf` from the environment level when running on new run-level `services`
+
 # 7.0.2
 FEATURES:
 - Add `service` level where a business service can be defined within `<product>-infra/terraform/<product>-<ecosystem>/<environment>/<services>/<serviceX>`. This ensures a one services AWS S3 bucket with multiple uniquely named terraform state files.

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -239,7 +239,7 @@ module Dome
       when 'services'
         @secrets.extract_certs
         FileUtils.mkdir_p 'plans'
-        command         = "terraform plan -refresh=true -out=#{@plan_file}"
+        command         = "terraform plan -refresh=true -out=#{@plan_file} -var-file=../../params/env.tfvars"
         failure_message = '[!] something went wrong when creating the service TF plan'
         execute_command(command, failure_message)
       when /^secrets-/

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '7.0.2'
+  VERSION = '7.0.3'
 end


### PR DESCRIPTION
Allows the use of params/env.tfvars from each services runlevel

tests:
ran locally this dome version and at a local infra under services with variables declared. Those variables were then populated at ../../params/env.tf

Note: cannot use variables.tf from environment directory because of current terraform version has a bug. 