### PR TITLE
bugs: handle linux outputs of aws-vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.1.1
+BUGFIX:
+- Handle outputs of `aws-vault` on Linux clients
+
 # 9.1.0
 FEATURE:
 - Check terraform version against .terraform-version before running

--- a/lib/dome/environment.rb
+++ b/lib/dome/environment.rb
@@ -200,7 +200,7 @@ module Dome
         raise 'Unable to assume role'
       end
 
-      env = output.split("\n").map { |var| Hash[*var.split('=', 2)] }.reduce({}, &:merge)
+      env = output.split("\n").grep(/^AWS/).map { |var| Hash[*var.split('=', 2)] }.reduce({}, &:merge)
 
       puts '[*] Exporting temporary credentials to environment variables '\
       "#{'AWS_ACCESS_KEY_ID'.colorize(:green)}, #{'AWS_SECRET_ACCESS_KEY'.colorize(:green)}"\

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '9.1.0'
+  VERSION = '9.1.1'
 end


### PR DESCRIPTION
### ISSUE

`dome` fails to handle `aws-vault` outputs of Linux clients
so filtered outputs with a simple regex can fix the issue (at least for *me*)

```
[*] Attempting to assume the role defined by your profile for content-dev.
Traceback (most recent call last):
	7: from /home/tron/dev/customers/aws/itv/content/infra/.direnv/bin/dome:29:in `<main>'
	6: from /home/tron/dev/customers/aws/itv/content/infra/.direnv/bin/dome:29:in `load'
	5: from /home/tron/devel/customers/aws/itv/content/infra/.direnv/ruby/bundler/gems/domed-city-ce1148c40d13/bin/dome:41:in `<top (required)>'
	4: from /home/tron/devel/customers/aws/itv/content/infra/.direnv/ruby/bundler/gems/domed-city-ce1148c40d13/lib/dome/terraform.rb:94:in `validate_environment'
	3: from /home/tron/devel/customers/aws/itv/content/infra/.direnv/ruby/bundler/gems/domed-city-ce1148c40d13/lib/dome/environment.rb:203:in `aws_credentials'
	2: from /home/tron/devel/customers/aws/itv/content/infra/.direnv/ruby/bundler/gems/domed-city-ce1148c40d13/lib/dome/environment.rb:203:in `map'
	1: from /home/tron/devel/customers/aws/itv/content/infra/.direnv/ruby/bundler/gems/domed-city-ce1148c40d13/lib/dome/environment.rb:203:in `block in aws_credentials'
/home/tron/devel/customers/aws/itv/content/infra/.direnv/ruby/bundler/gems/domed-city-ce1148c40d13/lib/dome/environment.rb:203:in `[]': odd number of arguments for Hash (ArgumentError)
```

`aws-vault` outputs on a Linux box
```
$ aws-vault exec content-dev-pe -- env
PATH=/home/tron/.asdf/installs/aws-vault/6.0.0/bin:/home/tron/dev/customers/aws/itv/content/infra/.direnv/bin:/home/tron/dev/customers/aws/itv/content/infra/.direnv/ruby/bin:/home/tron/.asdf/shims:/home/tron/.asdf/bin:/home/tron/.npm-global/bin:/home/tron/.tfenv/bin:/home/tron/.local/bin:/home/tron/bin:/home/tron/.cargo/bin:/home/tron/.npm-global/bin:/home/tron/.tfenv/bin:/home/tron/.local/bin:/home/tron/bin:/usr/share/Modules/bin:/home/tron/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/home/tron/.rvm/bin:/var/lib/snapd/snap/bin:/usr/local/go/bin:/home/tron/devel/go/bin:/home/tron/.krew/bin:/home/tron/.rvm/bin:/usr/local/go/bin:/home/tron/devel/go/bin:/home/tron/.krew/bin
SHELL=/bin/bash
SESSION_MANAGER=local/unix:@/tmp/.ICE-unix/3575,unix/unix:/tmp/.ICE-unix/3575
COLORTERM=truecolor
HISTCONTROL=ignoredups
XDG_MENU_PREFIX=gnome-
rvm_prefix=/home/tron
HISTSIZE=1000
HOSTNAME=sriracha
TERMINATOR_DBUS_PATH=/net/tenshu/Terminator2
GUESTFISH_OUTPUT=\e[0m
SSH_AUTH_SOCK=/run/user/1000/keyring/ssh
DIRENV_DIR=-/home/tron/dev/customers/aws/itv/content/infra
TERMINATOR_UUID=urn:uuid:de2619e5-c007-44ec-9afe-00e35b8ea104
XMODIFIERS=@im=ibus
DESKTOP_SESSION=gnome-xorg
SSH_AGENT_PID=3401
PWD=/home/tron/dev/customers/aws/itv/content/infra/terraform/content-dev/dev
XDG_SESSION_DESKTOP=gnome-xorg
LOGNAME=tron
XDG_SESSION_TYPE=x11
MODULESHOME=/usr/share/Modules
rvm_version=1.29.8 (latest)
MANPATH=:
XAUTHORITY=/run/user/1000/gdm/Xauthority
GUESTFISH_RESTORE=\e[0m
GJS_DEBUG_TOPICS=JS ERROR;JS LOG
WINDOWPATH=2
GDM_LANG=en_GB.UTF-8
HOME=/home/tron
USERNAME=tron
LANG=en_GB.UTF-8
LS_COLORS=rs=0:di=38;5;33:ln=38;5;51:mh=00:pi=40;38;5;11:so=38;5;13:do=38;5;5:bd=48;5;232;38;5;11:cd=48;5;232;38;5;3:or=48;5;232;38;5;9:mi=01;37;41:su=48;5;196;38;5;15:sg=48;5;11;38;5;16:ca=48;5;196;38;5;226:tw=48;5;10;38;5;16:ow=48;5;10;38;5;21:st=48;5;21;38;5;15:ex=38;5;40:*.tar=38;5;9:*.tgz=38;5;9:*.arc=38;5;9:*.arj=38;5;9:*.taz=38;5;9:*.lha=38;5;9:*.lz4=38;5;9:*.lzh=38;5;9:*.lzma=38;5;9:*.tlz=38;5;9:*.txz=38;5;9:*.tzo=38;5;9:*.t7z=38;5;9:*.zip=38;5;9:*.z=38;5;9:*.dz=38;5;9:*.gz=38;5;9:*.lrz=38;5;9:*.lz=38;5;9:*.lzo=38;5;9:*.xz=38;5;9:*.zst=38;5;9:*.tzst=38;5;9:*.bz2=38;5;9:*.bz=38;5;9:*.tbz=38;5;9:*.tbz2=38;5;9:*.tz=38;5;9:*.deb=38;5;9:*.rpm=38;5;9:*.jar=38;5;9:*.war=38;5;9:*.ear=38;5;9:*.sar=38;5;9:*.rar=38;5;9:*.alz=38;5;9:*.ace=38;5;9:*.zoo=38;5;9:*.cpio=38;5;9:*.7z=38;5;9:*.rz=38;5;9:*.cab=38;5;9:*.wim=38;5;9:*.swm=38;5;9:*.dwm=38;5;9:*.esd=38;5;9:*.jpg=38;5;13:*.jpeg=38;5;13:*.mjpg=38;5;13:*.mjpeg=38;5;13:*.gif=38;5;13:*.bmp=38;5;13:*.pbm=38;5;13:*.pgm=38;5;13:*.ppm=38;5;13:*.tga=38;5;13:*.xbm=38;5;13:*.xpm=38;5;13:*.tif=38;5;13:*.tiff=38;5;13:*.png=38;5;13:*.svg=38;5;13:*.svgz=38;5;13:*.mng=38;5;13:*.pcx=38;5;13:*.mov=38;5;13:*.mpg=38;5;13:*.mpeg=38;5;13:*.m2v=38;5;13:*.mkv=38;5;13:*.webm=38;5;13:*.webp=38;5;13:*.ogm=38;5;13:*.mp4=38;5;13:*.m4v=38;5;13:*.mp4v=38;5;13:*.vob=38;5;13:*.qt=38;5;13:*.nuv=38;5;13:*.wmv=38;5;13:*.asf=38;5;13:*.rm=38;5;13:*.rmvb=38;5;13:*.flc=38;5;13:*.avi=38;5;13:*.fli=38;5;13:*.flv=38;5;13:*.gl=38;5;13:*.dl=38;5;13:*.xcf=38;5;13:*.xwd=38;5;13:*.yuv=38;5;13:*.cgm=38;5;13:*.emf=38;5;13:*.ogv=38;5;13:*.ogx=38;5;13:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:
XDG_CURRENT_DESKTOP=GNOME
VTE_VERSION=6003
GUESTFISH_PS1=\[\e[1;32m\]><fs>\[\e[0;31m\] 
INVOCATION_ID=e08e9ff2c6474c8cbf49d061a735d591
TERMINATOR_DBUS_NAME=net.tenshu.Terminator21a9d5db22c73a993ff0b42f64b396873
MANAGERPID=3151
DIRENV_DIFF=eJzslN9vmzAQx_8XP4e6bjuSIO0BEtoQmpAQp8t4sUww4EAwsQn5UfV_n7pNzRqqSV21p-0F6b53fM7WfX2PoATGI5iYeAAMAFOxZrCSooAXVEUxVClfK6Mhh7x4JRblWktyEdK8kapiVtQNNRfLZu150ZLKRPzNXlsloUqpZHAkom3O1O-O8Fz8C-oUqpf4BD3nyHr9I1tTCXMeQlXQMvr-Pcc1rxyxmr2lX2SS7RriS6sPIcFTCxTPzrDm4_69TSxn_NofEavhcqsqsWZSQbpTkFc1XIqiYkUFeRFLCi8iLn9OBLRA3_Ht8QPpOz4wgPY-1On3LybuDewZMAAb7tVxhTbu0Z6aXq-9ub3paBUKwpi4lpb3ubQvefLAehTvvdQ6dAm2hoRr3SuC_GKItzfDcLJPs65JA3zJJ258nYy-3jFb3yyzgcBh4qJ8fru7WVCvtEJUX7HS0usotVa-WCykqD910SzHbewwcu91RlwvK-QQJ4qt9nSmXxOFs6QTOlopzPoWTdGh6yDkjrl9t2nPj5NsUciepgfupa8HJfZdB4XHjGq6XLUD4u2vOqZp9gnR5wGedz6DFrizR2Tgjew_H4XchgfQeuO9v3Oexgf6N0z3f9X826vm6VsAAAD__zzDStg=
GJS_DEBUG_OUTPUT=stderr
rvm_bin_path=/home/tron/.rvm/bin
GEM_HOME=/home/tron/dev/customers/aws/itv/content/infra/.direnv/ruby
MODULEPATH_modshare=/usr/share/modulefiles:1:/usr/share/Modules/modulefiles:1:/etc/modulefiles:1
XDG_SESSION_CLASS=user
TERM=xterm-256color
BUNDLE_BIN=/home/tron/dev/customers/aws/itv/content/infra/.direnv/bin
ASDF_DIR=/home/tron/.asdf
LESSOPEN=||/usr/bin/lesspipe.sh %s
BMA_MULTIPASS_DIR=/home/tron/.bash-my-aws/multipass-role-arns
USER=tron
MODULES_RUN_QUARANTINE=LD_LIBRARY_PATH
LOADEDMODULES=
DISPLAY=:0
SHLVL=1
GUESTFISH_INIT=\e[1;34m
QT_IM_MODULE=ibus
XDG_RUNTIME_DIR=/run/user/1000
KDEDIRS=/usr
JOURNAL_STREAM=8:68962
XDG_DATA_DIRS=/home/tron/.local/share/flatpak/exports/share/:/var/lib/flatpak/exports/share/:/usr/local/share/:/usr/share/:/var/lib/snapd/desktop
MODULEPATH=/etc/scl/modulefiles:/etc/scl/modulefiles:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles
GDMSESSION=gnome-xorg
DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
DIRENV_WATCHES=eJxszj1qKzEQAOC7qF48-t1Zbf_KB-lDirE0igVeCaTxOhBy9_TBJ_i-92_1RnJTu4JbPxhk9AaZT0iPKf3gMYGeE6qckHoTbgK1lUFw4XaOpBb1v2epB6vdhBjRoXXrov591SlT7TIe_LO8Mi6pt1I_IdfB7QS63_sTkg8bI-poAvF1Q1y9I11KNiEGq7UzPkXnrC-6ZK0R6ZpTRKI1bzka-6rj7Z_Ox28AAAD__6UZTU8=
MAIL=/var/spool/mail/tron
GIO_LAUNCHED_DESKTOP_FILE_PID=8347
GIO_LAUNCHED_DESKTOP_FILE=/usr/share/applications/terminator.desktop
rvm_path=/home/tron/.rvm
GOPATH=/home/tron/devel/go
MODULES_CMD=/usr/share/Modules/libexec/modulecmd.tcl
BASH_FUNC_switchml%%=() {  typeset swfound=1;
 if [ "${MODULES_USE_COMPAT_VERSION:-0}" = '1' ]; then
 typeset swname='main';
 if [ -e /usr/share/Modules/libexec/modulecmd.tcl ]; then
 typeset swfound=0;
 unset MODULES_USE_COMPAT_VERSION;
 fi;
 else
 typeset swname='compatibility';
 if [ -e /usr/share/Modules/libexec/modulecmd-compat ]; then
 typeset swfound=0;
 MODULES_USE_COMPAT_VERSION=1;
 export MODULES_USE_COMPAT_VERSION;
 fi;
 fi;
 if [ $swfound -eq 0 ]; then
 echo "Switching to Modules $swname version";
 source /usr/share/Modules/init/bash;
 else
 echo "Cannot switch to Modules $swname version, command not found";
 return 1;
 fi
}
BASH_FUNC_module%%=() {  _module_raw "$@" 2>&1
}
BASH_FUNC_scl%%=() {  if [ "$1" = "load" -o "$1" = "unload" ]; then
 eval "module $@";
 else
 /usr/bin/scl "$@";
 fi
}
BASH_FUNC__module_raw%%=() {  unset _mlshdbg;
 if [ "${MODULES_SILENT_SHELL_DEBUG:-0}" = '1' ]; then
 case "$-" in 
 *v*x*)
 set +vx;
 _mlshdbg='vx'
 ;;
 *v*)
 set +v;
 _mlshdbg='v'
 ;;
 *x*)
 set +x;
 _mlshdbg='x'
 ;;
 *)
 _mlshdbg=''
 ;;
 esac;
 fi;
 unset _mlre _mlIFS;
 if [ -n "${IFS+x}" ]; then
 _mlIFS=$IFS;
 fi;
 IFS=' ';
 for _mlv in ${MODULES_RUN_QUARANTINE:-};
 do
 if [ "${_mlv}" = "${_mlv##*[!A-Za-z0-9_]}" -a "${_mlv}" = "${_mlv#[0-9]}" ]; then
 if [ -n "`eval 'echo ${'$_mlv'+x}'`" ]; then
 _mlre="${_mlre:-}${_mlv}_modquar='`eval 'echo ${'$_mlv'}'`' ";
 fi;
 _mlrv="MODULES_RUNENV_${_mlv}";
 _mlre="${_mlre:-}${_mlv}='`eval 'echo ${'$_mlrv':-}'`' ";
 fi;
 done;
 if [ -n "${_mlre:-}" ]; then
 eval `eval ${_mlre}/usr/bin/tclsh /usr/share/Modules/libexec/modulecmd.tcl bash '"$@"'`;
 else
 eval `/usr/bin/tclsh /usr/share/Modules/libexec/modulecmd.tcl bash "$@"`;
 fi;
 _mlstatus=$?;
 if [ -n "${_mlIFS+x}" ]; then
 IFS=$_mlIFS;
 else
 unset IFS;
 fi;
 unset _mlre _mlv _mlrv _mlIFS;
 if [ -n "${_mlshdbg:-}" ]; then
 set -$_mlshdbg;
 fi;
 unset _mlshdbg;
 return $_mlstatus
}
AWS_VAULT=content-dev-pe
AWS_ACCESS_KEY_ID=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
AWS_SECRET_ACCESS_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
AWS_SESSION_TOKEN=XXXXXXXXXXXXXXXXXXXXXXX=
AWS_SECURITY_TOKEN=XXXXXXXXXXXXXXXXXXXXXXXX=
AWS_SESSION_EXPIRATION=2020-09-10T14:53:11Z
```