### PR TITLE
only warn on missing hiera lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.2.1
+BUGFIX:
+- Only warn on missing hiera lookups
+
 # 9.2.0
 FEATURE:
 - Add `ecoroles` level at the ecosystem

--- a/lib/dome/hiera_lookup.rb
+++ b/lib/dome/hiera_lookup.rb
@@ -93,7 +93,7 @@ module Dome
         if hiera_lookup
           puts "[*] Setting #{terraform_env_var.colorize(:green)}."
         else
-          puts "[!] Hiera lookup failed for '#{val}', so #{terraform_env_var} was not set.".colorize(:red)
+          puts "[!] Hiera lookup failed for '#{val}', so #{terraform_env_var} was not set.".colorize(:yellow)
         end
       end
 

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '9.2.0'
+  VERSION = '9.2.1'
 end

--- a/spec/hiera_spec.rb
+++ b/spec/hiera_spec.rb
@@ -23,7 +23,7 @@ describe Dome do
   it 'outputs the correct error message for a failed hiera lookup' do
     vars = { 'foo' => 'bar' }
     allow(hiera).to receive(:lookup).and_return(nil)
-    error_message = "\e[0;31;49m[!] Hiera lookup failed for 'bar', so TF_VAR_foo was not set.\e[0m\n\n"
+    error_message = "\e[0;33;49m[!] Hiera lookup failed for 'bar', so TF_VAR_foo was not set.\e[0m\n\n"
     expect { hiera.secret_env_vars(vars) }.to output(error_message).to_stdout
   end
 end


### PR DESCRIPTION
only warn on missing hiera lookups: sometimes it is expected for these to be missing if they aren't used in a particular environment/ecosystem. The red in the plan can be confusing.