### PR TITLE
Export Main Environment during Eco System Level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.3.0
+FEATURE:
+  - Export Main Environment when running actions at Ecosystem level to support the environment to ecosystem migration
 # 10.2.0
 FEATURE:
   - Check AWS session time before running. If the remaining session time is <20 minutes then clear the session and get a new one. If less than 40 minutes, check if the user wants to clear the session before continuing. This is for the case of long-running applys such as EKS upgrades.

--- a/lib/dome/environment.rb
+++ b/lib/dome/environment.rb
@@ -40,7 +40,7 @@ module Dome
         @services               = nil
 
       when 'ecosystem'
-        @environment            = nil
+        @environment            = directories[-1].split('-')[-1]
         @account                = directories[-1]
         @services               = nil
 

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '10.2.0'
+  VERSION = '10.3.0'
 end


### PR DESCRIPTION
While moving environment.tf to the ecosystem level, we need the main environment name set for the various variables it relies on.