### PR TITLE
set AWS_REGION rather than AWS_DEFAULT_REGION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 10.4.1
+BUGFIX:
+  - Set `AWS_REGION` envvar rather than `AWS_DEFAULT_REGION`
+    - this is to fix a [provider bug](https://github.com/hashicorp/terraform-provider-aws/issues/5981) that prevents you from creating S3 buckets outside of `eu-west-1`
+
 # 10.4.0
 FEATURE:
   - Show remaining seconds left on session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 10.4.1
-BUGFIX:
-  - Set `AWS_REGION` envvar rather than `AWS_DEFAULT_REGION`
+# 11.0.0
+BREAKING CHANGE:
+  - Do not set `AWS_DEFAULT_REGION`
+  - You now need to ensure that `region = eu-west-1` is added to your `~/.aws/config` profiles (you can regenerate using the latest [aws-profile-generator](https://github.com/ITV/cp-tools/blob/master/bin/aws-profile-generator.rb).
     - this is to fix a [provider bug](https://github.com/hashicorp/terraform-provider-aws/issues/5981) that prevents you from creating S3 buckets outside of `eu-west-1`
 
 # 10.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
-# 11.0.0
-BREAKING CHANGE:
-  - Do not set `AWS_DEFAULT_REGION`
-  - You now need to ensure that `region = eu-west-1` is added to your `~/.aws/config` profiles (you can regenerate using the latest [aws-profile-generator](https://github.com/ITV/cp-tools/blob/master/bin/aws-profile-generator.rb).
+# 10.4.1
+BUGFIX:
+  - Set `AWS_REGION` envvar rather than `AWS_DEFAULT_REGION`
     - this is to fix a [provider bug](https://github.com/hashicorp/terraform-provider-aws/issues/5981) that prevents you from creating S3 buckets outside of `eu-west-1`
 
 # 10.4.0

--- a/lib/dome/environment.rb
+++ b/lib/dome/environment.rb
@@ -12,7 +12,7 @@ module Dome
     include Dome::Level
 
     def initialize(directories = Dir.pwd.split('/'))
-      ENV['AWS_DEFAULT_REGION'] = 'eu-west-1'
+      ENV['AWS_REGION'] = 'eu-west-1'
 
       puts <<-'MSG'
              _

--- a/lib/dome/environment.rb
+++ b/lib/dome/environment.rb
@@ -12,6 +12,8 @@ module Dome
     include Dome::Level
 
     def initialize(directories = Dir.pwd.split('/'))
+      ENV['AWS_REGION'] = 'eu-west-1'
+
       puts <<-'MSG'
              _
           __| | ___  _ __ ___   ___

--- a/lib/dome/environment.rb
+++ b/lib/dome/environment.rb
@@ -12,8 +12,6 @@ module Dome
     include Dome::Level
 
     def initialize(directories = Dir.pwd.split('/'))
-      ENV['AWS_REGION'] = 'eu-west-1'
-
       puts <<-'MSG'
              _
           __| | ___  _ __ ___   ___

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '10.4.0'
+  VERSION = '10.4.1'
 end


### PR DESCRIPTION
BUGFIX:
  - Set `AWS_REGION` envvar rather than `AWS_DEFAULT_REGION`
    - this is to fix a [provider bug](https://github.com/hashicorp/terraform-provider-aws/issues/5981) that prevents you from creating S3 buckets outside of `eu-west-1`