### PR TITLE
Tf14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 11.0.0
+BREAKING:
+  - Update providers for namespace functionality as part of TF14 update
+  - Remove TF lock file when running TF plan
+  - This version should only be used when updating to TF14 (chromium release)
+
 # 10.4.0
 FEATURE:
   - Show remaining seconds left on session

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -235,7 +235,7 @@ module Dome
       case level
       when 'environment', 'services'
         params = " -var-file=params/env.tfvars"
-      end 
+      end
       command         = "terraform import#{params} #{arguments}"
       failure_message = "[!] something went wrong when doing terraform import #{arguments}"
       execute_command(command, failure_message)
@@ -345,15 +345,15 @@ module Dome
 
       return unless providers
 
-      providers.each do |name, version|
-        plugin_dirs << install_provider(name, version)
+      providers['provider'].each do |provider|
+        plugin_dirs << install_provider(provider)
       end
 
       plugin_dirs.map { |dir| "-plugin-dir #{dir}" }.join(' ')
     end
 
-    def install_provider(name, version)
-      puts "Installing provider #{name}:#{version} ...".colorize(:green)
+    def install_provider(provider)
+      puts "Installing provider #{provider['name']}:#{provider['version']} ...".colorize(:green)
 
       if RUBY_PLATFORM =~ /linux/
         arch = 'linux_amd64'
@@ -363,17 +363,17 @@ module Dome
         raise 'Invalid platform, only linux and darwin are supported.'
       end
 
-      uri = "https://releases.hashicorp.com/terraform-provider-#{name}/#{version}/terraform-provider-#{name}_#{version}_#{arch}.zip"
-      dir = File.join(Dir.home, '.terraform.d', 'providercache', name, version, 'registry.terraform.io', 'hashicorp', name, version, arch)
+      uri = "https://releases.hashicorp.com/terraform-provider-#{provider['name']}/#{provider['version']}/terraform-provider-#{provider['name']}_#{provider['version']}_#{arch}.zip"
+      dir = File.join(Dir.home, '.terraform.d', 'providercache', provider['name'], provider['version'], 'registry.terraform.io', provider['namespace'], provider['name'], provider['version'], arch)
 
       # This compat_dir is in place to provide migration between tf12 -> tf13
-      compat_dir = File.join(Dir.home, '.terraform.d', 'providercache', name, version, 'registry.terraform.io', '-', name, version, arch)
+      compat_dir = File.join(Dir.home, '.terraform.d', 'providercache', provider['name'], provider['version'], 'registry.terraform.io', '-', provider['name'], provider['version'], arch)
 
       # The directory to search for the plugin
-      plugin_dir = File.join(Dir.home, '.terraform.d', 'providercache', name, version)
+      plugin_dir = File.join(Dir.home, '.terraform.d', 'providercache', provider['name'], provider['version'])
       return plugin_dir unless Dir[dir].empty? || Dir[compat_dir].empty?
 
-      [dir, compat_dir].each do |createdir| 
+      [dir, compat_dir].each do |createdir|
         next unless Dir[createdir].empty?
         FileUtils.makedirs(createdir, mode: 0o0755)
 

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -199,6 +199,7 @@ module Dome
       puts '--- Deleting old plans'
       # delete_terraform_directory # Don't delete it
       delete_plan_file
+      delete_tf_lock_file
       @state.s3_state
       puts
       puts '--- Terraform init & plan ---'
@@ -303,6 +304,12 @@ module Dome
     def delete_plan_file
       puts '[*] Deleting previous terraform plan ...'.colorize(:green)
       FileUtils.rm_f @plan_file
+    end
+
+    def delete_tf_lock_file
+      puts '[*] Deleting previous terraform lock file ...'.colorize(:green)
+      terraform_lock_file = '.terraform.lock.hcl'
+      FileUtils.rm_f terraform_lock_file
     end
 
     def init

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '10.4.0'
+  VERSION = '10.5.0'
 end

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '10.5.0'
+  VERSION = '11.0.0'
 end


### PR DESCRIPTION
BREAKING:
  - Update providers for namespace functionality as part of TF14 update
  - Remove TF lock file when running TF plan
  - This version should only be used when updating to TF14 (chromium release)