### PR TITLE
add the option to use `-json` in plan/apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 12.3.0
+FEATURE:
+- add optional `--json` arg to use `-json` in plan/apply
+
 # 12.2.1
 BUGFIX:
 - add params at ecosystem level during import

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ $ bundle exec dome
   -r, --refresh          Refresh the state
   -c, --console          Spawn terraform console
   -u, --sudo             Assume itv-root instead of the role specified in profile
+  -j, --json             Pass the `-json` arg to plan and apply commands
   -v, --version          Print version and exit
   -h, --help             Show this message
   -e, --environment      Spawn sub-shell with the exported variables

--- a/bin/dome
+++ b/bin/dome
@@ -24,12 +24,13 @@ opts = Optimist.options do
   opt :refresh, 'Refresh the state'
   opt :console, 'Spawn terraform console'
   opt :sudo, 'Assume itv-root instead of the role specified in profile'
+  opt :json, 'Use -json for plan and apply commands'
   opt :environment, 'Spawn sub-shell with the exported variables'
 end
 
 Optimist.educate unless opts.value?(true)
 
-@dome = Dome::Terraform.new(sudo: opts[:sudo])
+@dome = Dome::Terraform.new(sudo: opts[:sudo], json: opts[:json])
 @dome.validate_tf_version
 
 if opts[:environment]

--- a/lib/dome/terraform.rb
+++ b/lib/dome/terraform.rb
@@ -10,7 +10,7 @@ module Dome
 
     attr_reader :state
 
-    def initialize(sudo: false)
+    def initialize(sudo: false, json:false)
       case level
       when 'environment'
         @environment = Dome::Environment.new
@@ -87,6 +87,8 @@ module Dome
         raise Dome::InvalidLevelError.new, level
       end
 
+      @extra_plan_args = json ? ' -json' : ''
+      @extra_apply_args = json ? ' -json' : ''
       @environment.sudo if sudo
     end
 
@@ -212,7 +214,7 @@ module Dome
 
     def apply
       @secrets.secret_env_vars
-      command         = "terraform apply #{@plan_file}"
+      command         = "terraform apply #{@extra_apply_args} #{@plan_file}"
       failure_message = '[!] something went wrong when applying the TF plan'
       @state.s3_state
       execute_command(command, failure_message)
@@ -254,40 +256,40 @@ module Dome
       when 'environment'
         @secrets.extract_certs
         FileUtils.mkdir_p 'plans'
-        command         = "terraform plan -refresh=true -out=#{@plan_file} -var-file=params/env.tfvars"
+        command         = "terraform plan #{@extra_plan_args} -refresh=true -out=#{@plan_file} -var-file=params/env.tfvars"
         failure_message = '[!] something went wrong when creating the environment TF plan'
         execute_command(command, failure_message)
       when 'ecosystem'
         FileUtils.mkdir_p 'plans'
-        command         = "terraform plan -refresh=true -out=#{@plan_file} -var-file=params/env.tfvars"
+        command         = "terraform plan #{@extra_plan_args} -refresh=true -out=#{@plan_file} -var-file=params/env.tfvars"
         failure_message = '[!] something went wrong when creating the ecosystem TF plan'
         execute_command(command, failure_message)
       when 'ecoroles'
         FileUtils.mkdir_p 'plans'
-        command         = "terraform plan -refresh=true -out=#{@plan_file}"
+        command         = "terraform plan #{@extra_plan_args} -refresh=true -out=#{@plan_file}"
         failure_message = '[!] something went wrong when creating the ecoroles TF plan'
         execute_command(command, failure_message)
       when 'product'
         FileUtils.mkdir_p 'plans'
-        command         = "terraform plan -refresh=true -out=#{@plan_file}"
+        command         = "terraform plan #{@extra_plan_args} -refresh=true -out=#{@plan_file}"
         failure_message = '[!] something went wrong when creating the product TF plan'
         execute_command(command, failure_message)
       when 'roles'
         @secrets.extract_certs
         FileUtils.mkdir_p 'plans'
-        command         = "terraform plan -refresh=true -out=#{@plan_file}"
+        command         = "terraform plan #{@extra_plan_args} -refresh=true -out=#{@plan_file}"
         failure_message = '[!] something went wrong when creating the role TF plan'
         execute_command(command, failure_message)
       when 'services'
         @secrets.extract_certs
         FileUtils.mkdir_p 'plans'
-        command         = "terraform plan -refresh=true -out=#{@plan_file} -var-file=../../params/env.tfvars"
+        command         = "terraform plan #{@extra_plan_args} -refresh=true -out=#{@plan_file} -var-file=../../params/env.tfvars"
         failure_message = '[!] something went wrong when creating the service TF plan'
         execute_command(command, failure_message)
       when /^secrets-/
         @secrets.extract_certs
         FileUtils.mkdir_p 'plans'
-        command         = "terraform plan -refresh=true -out=#{@plan_file}"
+        command         = "terraform plan #{@extra_plan_args} -refresh=true -out=#{@plan_file}"
         failure_message = '[!] something went wrong when creating the secret TF plan'
         execute_command(command, failure_message)
       else

--- a/lib/dome/version.rb
+++ b/lib/dome/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dome
-  VERSION = '12.2.1'
+  VERSION = '12.3.0'
 end


### PR DESCRIPTION
tested locally, with and without the new option

spec tests still pass, didn't add any new ones though because I am a bad person