### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # domed-city
 Simple CLI application that wraps the Terraform API.
 
-## Purpose
+## Purpose
 
 To consolidate, improve and enforce standards around ITV's use of Terraform across product teams.
 


### PR DESCRIPTION
One of the headers wasn’t rendering correctly. Adding a space fixes this